### PR TITLE
ci: do not trigger builds for certain CI related files

### DIFF
--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -11,6 +11,7 @@ spec:
     - name: release
       context: "release"
       source: "release.yaml"
+      ignore_changes: ".lighthouse/jenkins-x/(pullrequest|release|triggers).yaml|.npmrc"
       branches:
         - ^main$
         - ^master$


### PR DESCRIPTION
Ignore Jenkins-X config files tweaks.