### PR TITLE
chore(markdownlint): bump to v0.32.1 and simplify config with new ignore file

### DIFF
--- a/.lighthouse/jenkins-x/codeclimate.yaml
+++ b/.lighthouse/jenkins-x/codeclimate.yaml
@@ -36,7 +36,7 @@ spec:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
               name: ""
               resources: {}
-            - image: ghcr.io/jenkins-x/jx-boot:3.2.394
+            - image: ghcr.io/jenkins-x/jx-boot:3.3.2
               name: codeclimate-variables
               resources:
                 requests:

--- a/.lighthouse/jenkins-x/codeclimate.yaml
+++ b/.lighthouse/jenkins-x/codeclimate.yaml
@@ -27,9 +27,7 @@ spec:
             image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/release.yaml@versionStream
             name: ""
             resources:
-              requests:
-                cpu: 400m
-                memory: 512Mi
+              limits: {}
             volumeMounts:
               - mountPath: /tekton/home/npm
                 name: npmrc

--- a/.lighthouse/jenkins-x/coverage.yaml
+++ b/.lighthouse/jenkins-x/coverage.yaml
@@ -27,9 +27,7 @@ spec:
             image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/pullrequest.yaml@versionStream
             name: ""
             resources:
-              requests:
-                cpu: 400m
-                memory: 512Mi
+              limits: {}
             workingDir: /workspace/source
           steps:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream

--- a/.lighthouse/jenkins-x/coverage.yaml
+++ b/.lighthouse/jenkins-x/coverage.yaml
@@ -33,7 +33,7 @@ spec:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
               name: ""
               resources: {}
-            - image: ghcr.io/jenkins-x/jx-boot:3.2.394
+            - image: ghcr.io/jenkins-x/jx-boot:3.3.2
               name: codeclimate-variables
               resources:
                 requests:

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -20,9 +20,7 @@ spec:
             image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/pullrequest.yaml@versionStream
             name: ""
             resources:
-              requests:
-                cpu: 400m
-                memory: 512Mi
+              limits: {}
             workingDir: /workspace/source
           steps:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -22,9 +22,7 @@ spec:
             image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/release.yaml@versionStream
             name: ""
             resources:
-              requests:
-                cpu: 400m
-                memory: 512Mi
+              limits: {}
             volumeMounts:
               - mountPath: /tekton/home/npm
                 name: npmrc

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,8 +3,7 @@ module.exports = {
   'package.json': ['npm run format-package-json', 'npm run lint-package-json'],
   '.editorconfig': ['prettier --write'],
   LICENSE: ['prettier --write'],
-  // Typescript check does not respect per-file scopes.
-  '**/*.md': ['markdownlint --ignore charts --ignore content'],
+  '**/*.md': ['markdownlint'],
   '**/*.{css,html,json,less,md,mdx,scss,vue,yaml,yml}': ['prettier --write'],
   '**/*.{gql,graphql}': ['prettier --write'],
   '(**/*.{js,jsx,ts,tsx}|!.*.{js,ts})': [

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,7 @@
+node_modules/
+
+charts/
+
+dist/
+coverage/
+/**/__test__/**/*.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -15413,6 +15413,12 @@
       "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
       "dev": true
     },
+    "get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -19564,9 +19570,9 @@
       "dev": true
     },
     "linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
@@ -19870,12 +19876,6 @@
       "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
       "dev": true
     },
-    "lodash.differencewith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc=",
-      "dev": true
-    },
     "lodash.every": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
@@ -20165,14 +20165,14 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
@@ -20184,42 +20184,38 @@
           "dev": true
         },
         "entities": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
           "dev": true
         }
       }
     },
     "markdownlint": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-      "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.26.2.tgz",
+      "integrity": "sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==",
       "dev": true,
       "requires": {
-        "markdown-it": "12.0.4"
+        "markdown-it": "13.0.1"
       }
     },
     "markdownlint-cli": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.27.1.tgz",
-      "integrity": "sha512-p1VV6aSbGrDlpUWzHizAnSNEQAweVR3qUI/AIUubxW7BGPXziSXkIED+uRtSohUlRS/jmqp3Wi4es5j6fIrdeQ==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.32.1.tgz",
+      "integrity": "sha512-hVLQ+72b5esQd7I+IqzBEB4x/4C+wJaxS2M6nqaGoDwrtNY6gydGf5CIUJtQcXtqsM615++a8TZPsvEtH6H4gw==",
       "dev": true,
       "requires": {
-        "commander": "~7.1.0",
-        "deep-extend": "~0.6.0",
-        "get-stdin": "~8.0.0",
-        "glob": "~7.1.6",
-        "ignore": "~5.1.8",
-        "js-yaml": "^4.0.0",
-        "jsonc-parser": "~3.0.0",
-        "lodash.differencewith": "~4.5.0",
-        "lodash.flatten": "~4.4.0",
-        "markdownlint": "~0.23.1",
-        "markdownlint-rule-helpers": "~0.14.0",
-        "minimatch": "~3.0.4",
-        "minimist": "~1.2.5",
-        "rc": "~1.2.8"
+        "commander": "~9.4.0",
+        "get-stdin": "~9.0.0",
+        "glob": "~8.0.3",
+        "ignore": "~5.2.0",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "~3.1.0",
+        "markdownlint": "~0.26.1",
+        "markdownlint-rule-helpers": "~0.17.1",
+        "minimatch": "~5.1.0",
+        "run-con": "~1.2.11"
       },
       "dependencies": {
         "argparse": {
@@ -20228,16 +20224,38 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "commander": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
-          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+          "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
           "dev": true
         },
-        "get-stdin": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "dev": true
         },
         "js-yaml": {
@@ -20248,13 +20266,28 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "jsonc-parser": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+          "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
         }
       }
     },
     "markdownlint-rule-helpers": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.14.0.tgz",
-      "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz",
+      "integrity": "sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA==",
       "dev": true
     },
     "md5-file": {
@@ -20272,7 +20305,7 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "meant": {
@@ -23878,6 +23911,32 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
+    },
+    "run-con": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.11.tgz",
+      "integrity": "sha512-NEMGsUT+cglWkzEr4IFK21P4Jca45HqiAbIIZIBdX5+UZTB24Mb/21iNGgz9xZa8tL6vbW7CXmq7MFN42+VjNQ==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~3.0.0",
+        "minimist": "^1.2.6",
+        "strip-json-comments": "~3.1.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.0.tgz",
+          "integrity": "sha512-TxYQaeNW/N8ymDvwAxPyRbhMBtnEwuvaTYpOQkFx1nSeusgezHniEc/l35Vo4iCq/mMiTJbpD7oYxN98hFlfmw==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+          "dev": true
+        }
+      }
     },
     "run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okayd/gatsby-plugin-elasticsearch",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "A gatsby plugin to push to ElasticSearch based on a certain query",
   "keywords": [
     "gatsby",
@@ -35,7 +35,7 @@
     "lint": "run-p lint-eslint lint-markdown lint-package-json",
     "lint-eslint": "eslint --ext .js,.jsx,.ts,.tsx --format=pretty ./",
     "lint-eslint-watch": "onchange 'src/**/*' --initial --kill --delay 1000 -- npm run lint-eslint",
-    "lint-markdown": "markdownlint --ignore charts --ignore content --ignore .cache --ignore public --ignore node_modules '**/*.md' '.**/**/*.md'",
+    "lint-markdown": "markdownlint '**/*.md' '.**/**/*.md'",
     "lint-package-json": "npmPkgJsonLint -c ./.npmpackagejsonlintrc.json .",
     "lint-watch": "onchange 'src/**/*' --initial --kill --delay 1000 -- npm run lint",
     "test": "run-p --aggregate-output --print-label --silent lint typecheck jest",
@@ -86,7 +86,7 @@
     "jest-mock-extended": "1.0.18",
     "jest-raw-loader": "1.0.1",
     "lint-staged": "11.0.0",
-    "markdownlint-cli": "0.27.1",
+    "markdownlint-cli": "0.32.1",
     "npm-package-json-lint": "5.4.2",
     "npm-run-all": "4.1.5",
     "onchange": "7.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
+  "prConcurrentLimit": 3,
   "extends": ["config:base", ":rebaseStalePrs"],
   "semanticCommits": true,
   "stabilityDays": 3,
   "prCreation": "not-pending",
-  "labels": ["type: dependencies"]
+  "labels": ["type: dependencies", "updatebot"]
 }


### PR DESCRIPTION
MarkdownLint now supports a .markdownlintignore file which allows for a simpler setup

- #2nwzx8c